### PR TITLE
fix error in inkwell.dart

### DIFF
--- a/lib/widgets/ink_well.dart
+++ b/lib/widgets/ink_well.dart
@@ -33,7 +33,7 @@ class AzInkWell extends StatelessWidget{
   double? _radius;
   BorderRadius? _borderRadius;
   // ShapeBorder? customBorder;
-  bool? _enableFeedback = true;
+  bool _enableFeedback = true;
   bool _excludeFromSemantics = false;
   // FocusNode? focusNode;
   bool _canRequestFocus = true;


### PR DESCRIPTION
ERROR: The argument type 'bool?' can't be assigned to the parameter type 'bool'.

lib/widgets/ink_well.dart:237:23

    ╷
237 │       enableFeedback: _enableFeedback,
    │                       ^^^^^^^^^^^^^^^
    ╵

To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run flutter analyze lib/widgets/ink_well.dart

Fixed this